### PR TITLE
Support Selenium 4

### DIFF
--- a/weeklyTracking/utils/strava_web_scrape.py
+++ b/weeklyTracking/utils/strava_web_scrape.py
@@ -3,6 +3,8 @@ import logging
 import os
 from typing import List, Dict
 
+import selenium
+
 from bs4 import BeautifulSoup
 from django.contrib.auth.models import User
 from selenium import webdriver
@@ -43,9 +45,18 @@ def get_strava_leaderboards():
 
     if "GOOGLE_CHROME_BIN" in os.environ:  # Heroku
         chrome_options.binary_location = os.environ["GOOGLE_CHROME_BIN"]
-        driver = webdriver.Chrome(executable_path=os.environ["CHROMEDRIVER_PATH"], chrome_options=chrome_options)
+
+        if selenium.__version__.split(".")[0] == '4':
+            from selenium.webdriver.chrome.service import Service
+            service = Service(executable_path=os.environ["CHROMEDRIVER_PATH"])
+            driver = webdriver.Chrome(service=service, options=chrome_options)
+        else:
+            driver = webdriver.Chrome(executable_path=os.environ["CHROMEDRIVER_PATH"], chrome_options=chrome_options)
     else:
-        driver = webdriver.Chrome(chrome_options=chrome_options)
+        if selenium.__version__.split(".")[0] == '4':
+            driver = webdriver.Chrome(options=chrome_options)
+        else:
+            driver = webdriver.Chrome(chrome_options=chrome_options)
 
     # get URL of Strava club
     club_url = SettingStravaClub.objects.get().club_url


### PR DESCRIPTION
From Selenium 4, `chromedrive` path is specified in `executable_path` of `webdriver.service.Service` before passing it to `service` param of `webdriver.Chrome`. `chrome_options` is renamed to `options` as well.

Tested with 3.14.0 and latest version 4.10.0

Please noted: there is the issue with 3.14.1 and 3.141.0 but not be counted in this PR.